### PR TITLE
잘못된 credentials이거나 자가검진에 실패했을 때도 항상 성공했다고 나오는 현상 수정

### DIFF
--- a/api/getCheckResponse.ts
+++ b/api/getCheckResponse.ts
@@ -18,8 +18,7 @@ const check = async ({
     rspns09: '0',
   });
 
-  sendRequest('/stv_cvd_co01_000.do');
-  const res = await sendRequest('/stv_cvd_co02_000.do');
+  const res = await sendRequest('/stv_cvd_co01_000.do');
 
   return res;
 };

--- a/index.ts
+++ b/index.ts
@@ -26,8 +26,9 @@ import storedCredentials from './credentials.json';
   })() as Required<ICredentials>;
 
   const certification = await getCertification(credentials);
-  const { data } = await getCheckResponse({ certification, ...credentials });
-  if(data.resultSVO.rtnRsltCode == successText) {
+
+  const { data: { resultSVO: { rtnRsltCode: resultCode } } } = await getCheckResponse({ certification, ...credentials });
+  if (resultCode == successText) {
     drawSuccessBox();
   }
 })();

--- a/index.ts
+++ b/index.ts
@@ -26,8 +26,8 @@ import storedCredentials from './credentials.json';
   })() as Required<ICredentials>;
 
   const certification = await getCertification(credentials);
-  const { data: html } = await getCheckResponse({ certification, ...credentials });
-  if (html.includes(successText)) {
+  const { data } = await getCheckResponse({ certification, ...credentials });
+  if(data.resultSVO.rtnRsltCode == successText) {
     drawSuccessBox();
   }
 })();

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,4 +1,4 @@
-export const successText = '자가진단 참여를 완료하였습니다.';
+export const successText = 'SUCCESS';
 
 export const drawSuccessBox = () => {
   const timestamp = new Date().toLocaleString();


### PR DESCRIPTION
jsp를 사용하는 페이지이기 때문에 stv_cvd_co02_000.do는 서버에서 웹페이지를 가져오기 위한 엔드포인트이고 실제로 DB에 정보가 저장되지는 않습니다. 그래서 잘못된 정보를 넣어도 성공했다는 텍스트는 항상 나오는데, 그 텍스트로 성공 여부를 판단하고 있기 때문에 credentials가 잘못되어도 성공했다고 나옵니다.
대신 stv_cvd_co01_000.do는 실제로 DB에 정보를 넣는 엔드포인트이기 때문에 올바른 정보일 때만 SUCCESS 코드를 보내줍니다.

TODO
- [ ] 실패했을 때 실패 메시지 띄우기 (지금은 아무것도 안뜸)
- [ ] getCheckResponse의 리턴 타입 stv_cvd_co01_000.do에 맞게 수정